### PR TITLE
feat: ✨ add id arg

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,13 @@ jobs:
             Please make sure you have given us as much context as possible.
 ```
 
+### Available Variables
+
+| Name | Description |
+| --- | --- |
+| {{author}} | The GitHub username of the person who opened the issue / pull request |
+| {{id}} | The numeric id of the issue / pull request |
+
 ## License
 
 The scripts and documentation in this project are released under the [MIT License](LICENSE)

--- a/src/action.ts
+++ b/src/action.ts
@@ -14,7 +14,10 @@ export namespace Action {
         const { data } = await octokit.issues.createComment({
           ...context.repo,
           issue_number: payload.number,
-          body: Util.pickComment(comment, { author: payload.user.login }),
+          body: Util.pickComment(comment, {
+            author: payload.user.login,
+            id: payload.number.toString(),
+          }),
         })
 
         const reactions = Util.getReactions()


### PR DESCRIPTION
add `{{id}}` arg, allowing you to reference the issue / pull request id in the comment.

For example, our use case is to automatically generate a Netlify preview link in the comment:

```yaml
name: Add Netlify preview link to pull request
on: [pull_request]
jobs:
  run:
    runs-on: ubuntu-latest
    steps:
      - uses: bubkoo/auto-comment@v1
        with:
          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
          pullRequestOpened: >
            Preview on netlify: https://deploy-preview-{{ id }}--pull-request.netlify.app/
```