### PR TITLE
feat: add config for running in a date window

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,29 @@ jobs:
 | {{ id }} | The numeric id of the issue/pr |
 | {{ payload.* }} | The payload of the [issue/pr](https://docs.github.com/cn/rest/pulls/pulls#get-a-pull-request) |
 
+### Running within a specific date window
+
+You can configure the action to only run after a specific date, before a specific date, or between a start and end date.
+
+```yml
+name: Auto Comment
+on: [issues, pull_request]
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: wow-actions/auto-comment@v1
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          startDate: 2022-12-24
+          endDate: 2023-01-02
+          issuesOpenedComment: |
+            👋 @{{ author }}
+            Thank you for raising an issue.
+            We are on a company-wide holiday, and will only be investigating SEV-1 issues between Christmas and New Years.
+            If you have a SEV-1 issue, you can raise it by filing a "Production Outage" issue.
+```
+
 ## 🔖 License
 
 The scripts and documentation in this project are released under the [MIT License](LICENSE)

--- a/action.yml
+++ b/action.yml
@@ -280,6 +280,12 @@ inputs:
   pullRequestReviewRequestRemovedReactions:
     required: false
 
+  startDate:
+    required: false
+
+  endDate:
+    required: false
+
 runs:
   using: node16
   main: dist/index.js

--- a/src/action.ts
+++ b/src/action.ts
@@ -12,6 +12,22 @@ export namespace Action {
       core.info(`action: ${action}`)
       core.info(`event: ${Util.getEventName()}`)
 
+      const startDate = Util.getStartDate()
+      const endDate = Util.getEndDate()
+      if (startDate || endDate) {
+        core.info(`StartDate: ${startDate} - EndDate ${endDate}`)
+        const now = new Date()
+        core.info(`Today: ${now}`)
+
+        if (!(startDate && startDate < now)) {
+          throw new Error('Running before StartDate - not executing')
+        }
+        if (!(endDate && endDate > now)) {
+          throw new Error('Running after EndDate - not executing')
+        }
+        core.info('Running inside of configured time - executing')
+      }
+
       const comment = Util.getComment()
       const payload = context.payload.issue || context.payload.pull_request
       if (comment && payload) {

--- a/src/util.ts
+++ b/src/util.ts
@@ -98,4 +98,12 @@ export namespace Util {
 
     return null
   }
+
+  export function getStartDate() {
+    return new Date(Date.parse(core.getInput('startDate')))
+  }
+
+  export function getEndDate() {
+    return new Date(Date.parse(core.getInput('endDate')))
+  }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description

Add a `startDate` and `endDate` parameters, which are used to configure the behavior of executing the auto-comment workflow. Either or both `startDate` and `endDate` can be provided, and the current time is checked agains these dates to determine if the workflow can be executed. 

The `startDate` and `endDate` parameters are not  required, and as such, this feature is backwards compatible. 

### Motivation and Context

I want to support the case where we auto-comment only within a specific date-window. For example, if the company is on a company-wide holiday, I want to configure the auto-commenter to message out that the company is on break and what that means for providing support during this time. 

### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to change)
- [ ] **Enhancement** (changes that improvement of current feature or performance)
- [ ] **Refactoring** (changes that neither fixes a bug nor adds a feature)
- [ ] **Test Case** (changes that add missing tests or correct existing tests)
- [ ] **Code style optimization** (changes that do not affect the meaning of the code)
- [ ] **Docs** (changes that only update documentation)
- [ ] **Chore** (changes that don't modify src or test files)

### Self Check before Merge

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING**](CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.